### PR TITLE
Use correct syntax for \PackageError and \PackageWarning in beamerfontthemectao.sty

### DIFF
--- a/beamerfontthemectao.sty
+++ b/beamerfontthemectao.sty
@@ -14,7 +14,7 @@
 \IfFontExistsTF{Inter}{
   \setsansfont{Inter}
 }{
-  \PackageError{Font "Inter" could not be found, install using "tlmgr install inter" or by downloading and installing manually in your system.}
+\PackageError{beamerfontthemectao}{Font "Inter" could not be found}{Install the font using "tlmgr install inter" or by downloading and installing manually in your system.}
 }
 
 \unimathsetup{
@@ -29,7 +29,7 @@
 \IfFontExistsTF{Space Grotesk}{
   \newfontfamily\accentfont{Space Grotesk}
 }{
-  \PackageWarning{Font "Space Grotesk" not found, headings will use inter.}
+\PackageWarning{beamerfontthemectao}{Font "Space Grotesk" not found, headings will use inter.}
   \newfontfamily\accentfont{Inter}
 }
 


### PR DESCRIPTION
Thanks for having started this!

I was curious and I tried to compile it (premise: I am using [tectonic](https://tectonic-typesetting.github.io/en-US/)) and I encountered a couple of errors (apart from missing fonts that I installed separately).

Hope it helps!